### PR TITLE
feat: better debug output for CipherSuite and SslProtocol

### DIFF
--- a/security-framework/src/cipher_suite.rs
+++ b/security-framework/src/cipher_suite.rs
@@ -1,9 +1,11 @@
 //! Cipher Suites supported by Secure Transport
 
+use std::fmt;
+
 use security_framework_sys::cipher_suite::*;
 
 /// TLS cipher suites.
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
 pub struct CipherSuite(SSLCipherSuite);
 
 macro_rules! make_suites {
@@ -25,7 +27,23 @@ macro_rules! make_suites {
             pub fn to_raw(&self) -> SSLCipherSuite {
                 self.0
             }
+
+            pub(crate) fn cipher_name(&self) -> &'static str {
+                #[allow(unreachable_patterns)] // there's some overlap in the constant values
+                match () {
+                    $(_ if self == &Self::$suite => stringify!($suite)),+,
+                    _ => "UNKNOWN"
+                }
+            }
         }
+    }
+}
+
+impl fmt::Debug for CipherSuite {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CipherSuite")
+            .field(&format_args!("{:?} = {}", &self.0, self.cipher_name()))
+            .finish()
     }
 }
 

--- a/security-framework/src/secure_transport.rs
+++ b/security-framework/src/secure_transport.rs
@@ -398,7 +398,7 @@ impl SslClientCertificateState {
 }
 
 /// Specifies protocol versions.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct SslProtocol(SSLProtocol);
 
 impl SslProtocol {
@@ -439,6 +439,33 @@ impl SslProtocol {
 
     /// All supported TLS/SSL versions are accepted.
     pub const ALL: Self = Self(kSSLProtocolAll);
+}
+
+impl SslProtocol {
+    pub(crate) fn protocol_name(&self) -> &'static str {
+        match () {
+            _ if self.0 == kSSLProtocol3 => "SSL3",
+            _ if self.0 == kTLSProtocol1 => "TLS1",
+            _ if self.0 == kTLSProtocol11 => "TLS11",
+            _ if self.0 == kTLSProtocol12 => "TLS12",
+            _ if self.0 == kTLSProtocol13 => "TLS13",
+            _ if self.0 == kSSLProtocol2 => "SSL2",
+            _ if self.0 == kDTLSProtocol1 => "DTLS1",
+            _ if self.0 == kSSLProtocol3Only => "SSL3_ONLY",
+            _ if self.0 == kTLSProtocol1Only => "TLS1_ONLY",
+            _ if self.0 == kSSLProtocolAll => "ALL",
+            _ if self.0 == kSSLProtocolUnknown => "UNKNOWN",
+            _ => "UNKNOWN",
+        }
+    }
+}
+
+impl fmt::Debug for SslProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SslProtocol")
+            .field(&format_args!("{:?} = {}", self.0, self.protocol_name()))
+            .finish()
+    }
 }
 
 declare_TCFType! {


### PR DESCRIPTION
tls_client example used to print:

```
negotiated cipher: CipherSuite(49199)
negotiated version: SslProtocol(8)
```

now prints:

```
negotiated cipher: CipherSuite(49199 = TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256)
negotiated version: SslProtocol(8 = TLS12)
```